### PR TITLE
Don't add multiple nodes to any "Defs" node

### DIFF
--- a/Patches/Patch.xml
+++ b/Patches/Patch.xml
@@ -41,7 +41,7 @@
 		<WarningFail>Animal Collab Proj not detected, ignoring it's compatibility sequence</WarningFail>
 	  </li>
 	  <li Class="PatchOperationAdd">
-	    <xpath>Defs</xpath>
+	    <xpath>/Defs</xpath>
 		<value>
 		
 		  <ThingDef ParentName="FleeceBase">


### PR DESCRIPTION
Using <xpath>Defs</xpath> will match against ANY node "Defs" - so if a modder has something with "Defs" in the XML, you'd be adding to it.

Specifying <xpath>/Defs</xpath> avoids that risk and will be much faster, as xpath doesn't need to search through the entire XML tree.